### PR TITLE
Restore "bin" entry in package.json

### DIFF
--- a/pkg/package.json
+++ b/pkg/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/mozilla-services/audit-filter"
   },
+  "bin": "cli.js",
   "files": [
     "audit_filter_bg.wasm",
     "audit_filter.js",


### PR DESCRIPTION
The "bin" entry in package.json file, seems to have been
accidentally removed in commit e08d70d4f156142

This resulted in the executable not getting placed into the
correct path when installing via npm, so that the
"audit-filter" CLI command shown in the README doesn't
work.