### PR TITLE
Added dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/pkg/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "cargo"
       - "dependencies"


### PR DESCRIPTION
@g-k Hopefully this is what you are looking for, there are many more configuration options but I wasn't sure what would be preferred. Some useful options may be `open-pull-requests-limit`, `reviewers`, `assignees` and `target-branch`. Let me know if you want to add options or change the current ones. As of now, you only need to make these new labels: `npm`, `cargo`, `dependencies`.
Resolves #116. Security alerts can also be enabled from the Security tab of the repo. 